### PR TITLE
Release v3.2.12- Updated default HLS demo stream URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.12] - 2026-03-31
+
+### Changed
+
+- Updated default HLS demo stream URL
+
 ## [3.2.11] - 2026-03-10
 
 ### Changed

--- a/solution-manifest.yaml
+++ b/solution-manifest.yaml
@@ -1,6 +1,6 @@
 id: SO9672
 name: live-streaming-on-aws-with-amazon-s3
-version: v3.2.11
+version: v3.2.12
 cloudformation_templates:
   - template: live-streaming-on-aws-with-amazon-s3.template
     main_template: true

--- a/source/constructs/lib/live-streaming.ts
+++ b/source/constructs/lib/live-streaming.ts
@@ -54,7 +54,7 @@ export class LiveStreaming extends cdk.Stack {
         const pullUrl = new cdk.CfnParameter(this, 'PullUrl', {
             type: 'String',
             description: 'For URL PULL input type ONLY, specify the primary source URL, this should be a HTTP or HTTPS link to the stream manifest file.',
-            default: 'https://d15an60oaeed9r.cloudfront.net/live_stream_v2/sports_reel_with_markers.m3u8'
+            default: 'https://fcd796e21ed48a1abb4824e834c02632.p05sqb.channel-assembly.mediatailor.us-west-2.amazonaws.com/v1/channel/Live-event-framework-source-DO-NOT-DELETE/index.m3u8'
         });
         const pullUser = new cdk.CfnParameter(this, 'PullUser', {
             type: 'String',

--- a/source/constructs/package-lock.json
+++ b/source/constructs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "live-streaming-on-aws-with-amazon-s3",
-  "version": "3.2.10",
+  "version": "3.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "live-streaming-on-aws-with-amazon-s3",
-      "version": "3.2.10",
+      "version": "3.2.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-solutions-constructs/aws-cloudfront-s3": "^2.86.0",

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "live-streaming-on-aws-with-amazon-s3",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com/solutions"

--- a/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
+++ b/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`LiveStreaming Stack Test 1`] = `
 {
-  Description: (SO0109) Live Streaming on AWS with Amazon S3 Solution %%VERSION%%,
+  Description: (SO9672) Live Streaming on AWS with Amazon S3 Solution %%VERSION%%,
   Mappings: {
     AnonymizedData: {
       SendAnonymizedData: {
@@ -312,7 +312,7 @@ exports[`LiveStreaming Stack Test 1`] = `
       Type: String,
     },
     PullUrl: {
-      Default: https://d15an60oaeed9r.cloudfront.net/live_stream_v2/sports_reel_with_markers.m3u8,
+      Default: https://fcd796e21ed48a1abb4824e834c02632.p05sqb.channel-assembly.mediatailor.us-west-2.amazonaws.com/v1/channel/Live-event-framework-source-DO-NOT-DELETE/index.m3u8,
       Description: For URL PULL input type ONLY, specify the primary source URL, this should be a HTTP or HTTPS link to the stream manifest file.,
       Type: String,
     },
@@ -348,7 +348,7 @@ exports[`LiveStreaming Stack Test 1`] = `
             Arn,
           ],
         },
-        SolutionId: SO0109,
+        SolutionId: SO9672,
         Type: {
           Ref: InputType,
         },
@@ -523,7 +523,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0109,
+            Value: SO9672,
           },
         ],
       },
@@ -605,7 +605,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0109,
+            Value: SO9672,
           },
         ],
         VersioningConfiguration: {
@@ -646,7 +646,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0109,
+            Value: SO9672,
           },
         ],
         VersioningConfiguration: {
@@ -837,7 +837,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0109,
+            Value: SO9672,
           },
         ],
         VersioningConfiguration: {
@@ -1030,7 +1030,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0109,
+            Value: SO9672,
           },
         ],
         VersioningConfiguration: {
@@ -1156,7 +1156,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Description: CFN Custom resource to copy assets to S3 and get the MediaConvert endpoint,
         Environment: {
           Variables: {
-            SOLUTION_IDENTIFIER: AwsSolution/SO0109/%%VERSION%%,
+            SOLUTION_IDENTIFIER: AwsSolution/SO9672/%%VERSION%%,
           },
         },
         Handler: index.handler,
@@ -1170,7 +1170,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0109,
+            Value: SO9672,
           },
         ],
         Timeout: 30,
@@ -1320,7 +1320,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0109,
+            Value: SO9672,
           },
         ],
       },
@@ -1449,7 +1449,7 @@ exports[`LiveStreaming Stack Test 1`] = `
         Tags: [
           {
             Key: SolutionId,
-            Value: SO0109,
+            Value: SO9672,
           },
         ],
       },


### PR DESCRIPTION
## [3.2.12] - 2026-03-31

### Changed

- Updated default HLS demo stream URL

### Details

- Bumped version to 3.2.12 in `package.json`, `solution-manifest.yaml`, and `CHANGELOG.md`
- Refreshed `npm` dependencies and `package-lock.json` files
- Updated CDK snapshot to reflect current template state
- All unit tests passing (constructs: 1/1, custom-resource: 36/36)
